### PR TITLE
Fix: Sort pages by date for both paginated and non-paginated views

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,9 +5,9 @@
 
 {% if config.extra.list_pages %}
 {% if paginator %}
-{% set pages = paginator.pages %}
+{% set pages = paginator.pages | sort(attribute="date") | reverse %}
 {% else %}
-{% set pages = section.pages %}
+{% set pages = section.pages | sort(attribute="date") | reverse %}
 {% endif %}
 <ul>
 {% for page in pages %}


### PR DESCRIPTION
### Title: Sort Pages by Date for Improved User Experience

#### Description:
This pull request addresses the issue of page ordering on the index page by implementing sorting for both paginated and non-paginated views. Previously, only non-paginated pages were sorted by date, which could lead to confusion for users navigating through the content.

#### Changes Made:
- Updated the index.html template to sort `paginator.pages` and `section.pages` by date in descending order (newest first).
- Ensured a consistent display of content across both paginated and non-paginated views.

#### Before and After:
Before
![image](https://github.com/user-attachments/assets/4ebc0dbb-8dea-4d5e-b967-69e03ae76967)


After
![image](https://github.com/user-attachments/assets/3d050df3-5e61-40e2-b6c7-a28b87e27395)


This enhancement improves the overall user experience by ensuring that the most recent content is always displayed at the top of the list, making it easier for users to find the latest updates.